### PR TITLE
Use standard AWS IAM Identity Center (SSO) flow for credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ If you have completed the above steps or already have your permissions and crede
 
 On the first run (or when credentials expire), you will be prompted to sign in with AWS IAM Identity Center (via `aws configure sso` / `aws sso login`). The credentials are stored in `state/.aws/` and persist across Isaac Automator restarts.
 
+By default the sign-in uses the AWS SSO **device-code flow** (open a URL and enter a code), which works on headless and remote (SSH) hosts where a local browser is not reachable. If you are on a machine with a local browser and prefer the browser-based flow, set `AWS_SSO_USE_DEVICE_CODE=0` on the host before running `./run`.
+
 Tip: Run `./deploy-aws --help` to see more options.
 
 #### GCP

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ If you have completed the above steps or already have your permissions and crede
 ./deploy-aws
 ```
 
-On the first run (or when credentials expire), you will be prompted to enter your AWS credentials (via `aws configure`). The credentials are stored in `state/.aws/` and persist across Isaac Automator restarts.
+On the first run (or when credentials expire), you will be prompted to sign in with AWS IAM Identity Center (via `aws configure sso` / `aws sso login`). The credentials are stored in `state/.aws/` and persist across Isaac Automator restarts.
 
 Tip: Run `./deploy-aws --help` to see more options.
 
@@ -301,7 +301,7 @@ Options:
                                 [default: g6e.2xlarge]
   --region TEXT                 AWS Region.  [default: us-east-1]
 
-Note: AWS credentials are managed via `aws configure` and stored in
+Note: AWS credentials are managed via `aws configure sso` / `aws sso login` and stored in
 `state/.aws/`. You will be prompted to enter them on first run or when
 they expire.
 ```
@@ -446,7 +446,7 @@ Each cloud provider's credentials are stored inside the `state/` directory so th
 
 | Cloud         | Storage Location      | How Credentials Are Set                                                          |
 | ------------- | --------------------- | -------------------------------------------------------------------------------- |
-| AWS           | `state/.aws/` or env  | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars when set on the host; otherwise SSO login |
+| AWS           | `state/.aws/` or env  | `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars when set on the host; otherwise AWS IAM Identity Center via `aws configure sso` / `aws sso login` |
 | GCP           | `state/.gcp/`         | `gcloud auth login` — prompted during the first deployment                       |
 | Azure         | `state/.azure/`       | `az login` — prompted during the first deployment                                |
 | Alibaba Cloud | Environment variables | `ALIYUN_ACCESS_KEY` and `ALIYUN_SECRET_KEY` — passed from the host via `./run`   |

--- a/run
+++ b/run
@@ -20,7 +20,9 @@ for var in \
   AWS_ACCESS_KEY_ID \
   AWS_SECRET_ACCESS_KEY \
   AWS_SESSION_TOKEN \
-  AWS_DEFAULT_REGION; do
+  AWS_DEFAULT_REGION \
+  AWS_PROFILE \
+  AWS_SSO_USE_DEVICE_CODE; do
   if [[ -n "${!var}" ]]; then
     ENV_ARGS+=(-e "${var}=${!var}")
   fi

--- a/src/python/aws.py
+++ b/src/python/aws.py
@@ -20,6 +20,7 @@ Utils for AWS
 
 import json
 import os
+import shlex
 import sys
 from pathlib import Path
 
@@ -48,13 +49,19 @@ def _aws_env_credentials_set():
 AWS_STATE_DIR = f"{config['state_dir']}/.aws"
 
 
-def _aws_cli_get(key, verbose=False):
+def _aws_profile():
+    """AWS CLI profile used by the default credential-chain SSO flow."""
+    return os.environ.get("AWS_PROFILE") or "default"
+
+
+def _aws_cli_get(key, verbose=False, profile=None):
     """
     Read a value from the AWS CLI configuration.
     Returns the value or empty string if not set.
     """
+    profile_arg = f" --profile {shlex.quote(profile)}" if profile else ""
     res = shell_command(
-        f"aws configure get {key}",
+        f"aws configure get {key}{profile_arg}",
         verbose=verbose,
         exit_on_error=False,
         capture_output=True,
@@ -204,14 +211,48 @@ def _aws_export_credentials(verbose=False):
     return True
 
 
+def _aws_sso_profile_configured(verbose=False):
+    """
+    True when the selected AWS CLI profile has enough SSO configuration to log in.
+    Supports both current sso-session profiles and legacy inline SSO profiles.
+    """
+    profile = _aws_profile()
+    sso_account_id = _aws_cli_get(
+        "sso_account_id", verbose=verbose, profile=profile
+    )
+    sso_role_name = _aws_cli_get("sso_role_name", verbose=verbose, profile=profile)
+    sso_session = _aws_cli_get("sso_session", verbose=verbose, profile=profile)
+    sso_start_url = _aws_cli_get("sso_start_url", verbose=verbose, profile=profile)
+
+    return bool(
+        sso_account_id and sso_role_name and (sso_session or sso_start_url)
+    )
+
+
 def _aws_sso_login(verbose=False):
     """
-    Run `aws login --remote` to authenticate via SSO.
+    Authenticate with AWS IAM Identity Center using the standard AWS CLI SSO flow.
     """
     Path(AWS_STATE_DIR).mkdir(parents=True, exist_ok=True)
-    click.echo(colorize_info("* Running `aws login --remote`..."))
+    profile = _aws_profile()
+
+    if _aws_sso_profile_configured(verbose=verbose):
+        click.echo(colorize_info(f"* Running `aws sso login --profile {profile}`..."))
+        shell_command(
+            f"aws sso login --profile {shlex.quote(profile)}",
+            verbose=verbose,
+            exit_on_error=False,
+        )
+        return
+
+    click.echo(
+        colorize_info(
+            f"* No AWS SSO profile is configured. Running"
+            f" `aws configure sso --profile {profile}`..."
+        )
+    )
     shell_command(
-        "aws login --remote",
+        f"aws configure sso --profile {shlex.quote(profile)}",
         verbose=verbose,
         exit_on_error=False,
     )
@@ -225,7 +266,9 @@ def aws_validate_credentials(deployment_name=None, region=None, verbose=False):
       1. AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY env vars (validated via STS;
          no SSO fallback and no writes to the AWS config file).
       2. SSO login flow: clears any stale exported credentials, checks the
-         default credential chain, and if invalid runs `aws login --remote`.
+         default credential chain, and if invalid runs the standard AWS CLI
+         SSO flow (`aws sso login` for configured profiles, or
+         `aws configure sso` otherwise).
          After a successful login, exports resolved credentials so Terraform
          and Packer can use them.
 

--- a/src/python/aws.py
+++ b/src/python/aws.py
@@ -58,11 +58,18 @@ def _aws_cli_get(key, verbose=False, profile=None):
     """
     Read a value from the AWS CLI configuration.
     Returns the value or empty string if not set.
+
+    The retrieved value is never echoed (even in verbose mode) since some
+    keys (e.g. aws_secret_access_key, aws_session_token) are secrets.
     """
     profile_arg = f" --profile {shlex.quote(profile)}" if profile else ""
+    if verbose:
+        click.echo(
+            colorize_info(f"* Running `aws configure get {key}{profile_arg}`...")
+        )
     res = shell_command(
         f"aws configure get {key}{profile_arg}",
-        verbose=verbose,
+        verbose=False,
         exit_on_error=False,
         capture_output=True,
     )
@@ -74,10 +81,15 @@ def _aws_cli_get(key, verbose=False, profile=None):
 def aws_cli_set(key, value, verbose=False):
     """
     Set a value in the AWS CLI configuration.
+
+    The value is never echoed (even in verbose mode) since it may be a
+    secret such as aws_secret_access_key or aws_session_token.
     """
+    if verbose:
+        click.echo(colorize_info(f"* Running `aws configure set {key} <hidden>`..."))
     shell_command(
         f"aws configure set {key} '{value}'",
-        verbose=verbose,
+        verbose=False,
         exit_on_error=True,
         capture_output=True,
     )
@@ -171,9 +183,11 @@ def _aws_export_credentials(verbose=False):
     config so that tools like Terraform can use them via the default
     credential chain.
     """
+    if verbose:
+        click.echo(colorize_info("* Running `aws configure export-credentials`..."))
     res = shell_command(
         "aws configure export-credentials --format process",
-        verbose=verbose,
+        verbose=False,
         exit_on_error=False,
         capture_output=True,
     )

--- a/src/python/aws.py
+++ b/src/python/aws.py
@@ -54,6 +54,23 @@ def _aws_profile():
     return os.environ.get("AWS_PROFILE") or "default"
 
 
+def _aws_use_device_code():
+    """
+    Whether to use the SSO device-code flow instead of the browser flow.
+
+    Defaults to True: Isaac Automator always runs inside a container, often
+    over SSH on a headless host, where the browser flow's localhost callback
+    cannot reach the user's browser. The device-code flow only needs the user
+    to open a URL and enter a code, so it works everywhere. Set
+    AWS_SSO_USE_DEVICE_CODE to a falsey value (0/false/no) to force the
+    browser-based flow instead.
+    """
+    val = os.environ.get("AWS_SSO_USE_DEVICE_CODE")
+    if val is None:
+        return True
+    return val.strip().lower() not in ("0", "false", "no", "")
+
+
 def _aws_cli_get(key, verbose=False, profile=None):
     """
     Read a value from the AWS CLI configuration.
@@ -246,14 +263,22 @@ def _aws_sso_profile_configured(verbose=False):
 def _aws_sso_login(verbose=False):
     """
     Authenticate with AWS IAM Identity Center using the standard AWS CLI SSO flow.
+
+    Uses the device-code flow by default so authentication works on headless
+    or remote (SSH) hosts; see _aws_use_device_code().
     """
     Path(AWS_STATE_DIR).mkdir(parents=True, exist_ok=True)
     profile = _aws_profile()
+    device_code_arg = " --use-device-code" if _aws_use_device_code() else ""
 
     if _aws_sso_profile_configured(verbose=verbose):
-        click.echo(colorize_info(f"* Running `aws sso login --profile {profile}`..."))
+        click.echo(
+            colorize_info(
+                f"* Running `aws sso login --profile {profile}{device_code_arg}`..."
+            )
+        )
         shell_command(
-            f"aws sso login --profile {shlex.quote(profile)}",
+            f"aws sso login --profile {shlex.quote(profile)}{device_code_arg}",
             verbose=verbose,
             exit_on_error=False,
         )
@@ -262,11 +287,11 @@ def _aws_sso_login(verbose=False):
     click.echo(
         colorize_info(
             f"* No AWS SSO profile is configured. Running"
-            f" `aws configure sso --profile {profile}`..."
+            f" `aws configure sso --profile {profile}{device_code_arg}`..."
         )
     )
     shell_command(
-        f"aws configure sso --profile {shlex.quote(profile)}",
+        f"aws configure sso --profile {shlex.quote(profile)}{device_code_arg}",
         verbose=verbose,
         exit_on_error=False,
     )

--- a/src/tests/aws.test.py
+++ b/src/tests/aws.test.py
@@ -4,7 +4,11 @@ import os
 import unittest
 from unittest import mock
 
-from src.python.aws import _aws_env_credentials_set, aws_load_credentials
+from src.python.aws import (
+    _aws_env_credentials_set,
+    _aws_sso_profile_configured,
+    aws_load_credentials,
+)
 
 
 class Test_AwsEnvCredentialsSet(unittest.TestCase):
@@ -64,6 +68,47 @@ class Test_AwsLoadCredentials(unittest.TestCase):
         self.assertEqual(creds["aws_secret_access_key"], "envsecret")
         self.assertEqual(creds["aws_session_token"], "envtoken")
         self.assertEqual(creds["region"], "eu-west-1")
+
+
+class Test_AwsSsoProfileConfigured(unittest.TestCase):
+    @mock.patch("src.python.aws._aws_profile", return_value="default")
+    @mock.patch("src.python.aws._aws_cli_get")
+    def test_sso_session_profile_configured(self, mock_cli_get, mock_profile):
+        values = {
+            "sso_account_id": "111122223333",
+            "sso_role_name": "DeveloperAccess",
+            "sso_session": "company-sso",
+            "sso_start_url": "",
+        }
+        mock_cli_get.side_effect = lambda key, **kwargs: values[key]
+
+        self.assertTrue(_aws_sso_profile_configured())
+
+    @mock.patch("src.python.aws._aws_profile", return_value="default")
+    @mock.patch("src.python.aws._aws_cli_get")
+    def test_legacy_sso_profile_configured(self, mock_cli_get, mock_profile):
+        values = {
+            "sso_account_id": "111122223333",
+            "sso_role_name": "DeveloperAccess",
+            "sso_session": "",
+            "sso_start_url": "https://identitycenter.amazonaws.com/ssoins-example",
+        }
+        mock_cli_get.side_effect = lambda key, **kwargs: values[key]
+
+        self.assertTrue(_aws_sso_profile_configured())
+
+    @mock.patch("src.python.aws._aws_profile", return_value="default")
+    @mock.patch("src.python.aws._aws_cli_get")
+    def test_missing_account_is_not_configured(self, mock_cli_get, mock_profile):
+        values = {
+            "sso_account_id": "",
+            "sso_role_name": "DeveloperAccess",
+            "sso_session": "company-sso",
+            "sso_start_url": "",
+        }
+        mock_cli_get.side_effect = lambda key, **kwargs: values[key]
+
+        self.assertFalse(_aws_sso_profile_configured())
 
 
 if __name__ == "__main__":

--- a/src/tests/aws.test.py
+++ b/src/tests/aws.test.py
@@ -10,7 +10,9 @@ from unittest import mock
 from src.python.aws import (
     _aws_env_credentials_set,
     _aws_export_credentials,
+    _aws_sso_login,
     _aws_sso_profile_configured,
+    _aws_use_device_code,
     aws_cli_set,
     aws_load_credentials,
 )
@@ -114,6 +116,69 @@ class Test_AwsSsoProfileConfigured(unittest.TestCase):
         mock_cli_get.side_effect = lambda key, **kwargs: values[key]
 
         self.assertFalse(_aws_sso_profile_configured())
+
+
+class Test_AwsUseDeviceCode(unittest.TestCase):
+    def test_default_is_device_code(self):
+        env = dict(os.environ)
+        env.pop("AWS_SSO_USE_DEVICE_CODE", None)
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertTrue(_aws_use_device_code())
+
+    def test_disabled_values(self):
+        for val in ("0", "false", "no", "False", "NO", ""):
+            with mock.patch.dict(
+                os.environ, {"AWS_SSO_USE_DEVICE_CODE": val}, clear=False
+            ):
+                self.assertFalse(_aws_use_device_code(), msg=val)
+
+    def test_enabled_values(self):
+        for val in ("1", "true", "yes", "True"):
+            with mock.patch.dict(
+                os.environ, {"AWS_SSO_USE_DEVICE_CODE": val}, clear=False
+            ):
+                self.assertTrue(_aws_use_device_code(), msg=val)
+
+
+class Test_AwsSsoLoginCommand(unittest.TestCase):
+    @mock.patch("src.python.aws.Path")
+    @mock.patch("src.python.aws._aws_sso_profile_configured", return_value=True)
+    @mock.patch("src.python.aws._aws_profile", return_value="default")
+    @mock.patch("src.python.aws.shell_command")
+    def test_login_uses_device_code_by_default(self, mock_shell, *_):
+        env = dict(os.environ)
+        env.pop("AWS_SSO_USE_DEVICE_CODE", None)
+        with mock.patch.dict(os.environ, env, clear=True):
+            _aws_sso_login()
+        cmd = mock_shell.call_args.args[0]
+        self.assertIn("aws sso login", cmd)
+        self.assertIn("--use-device-code", cmd)
+
+    @mock.patch("src.python.aws.Path")
+    @mock.patch("src.python.aws._aws_sso_profile_configured", return_value=True)
+    @mock.patch("src.python.aws._aws_profile", return_value="default")
+    @mock.patch("src.python.aws.shell_command")
+    def test_login_browser_flow_when_disabled(self, mock_shell, *_):
+        with mock.patch.dict(
+            os.environ, {"AWS_SSO_USE_DEVICE_CODE": "0"}, clear=False
+        ):
+            _aws_sso_login()
+        cmd = mock_shell.call_args.args[0]
+        self.assertIn("aws sso login", cmd)
+        self.assertNotIn("--use-device-code", cmd)
+
+    @mock.patch("src.python.aws.Path")
+    @mock.patch("src.python.aws._aws_sso_profile_configured", return_value=False)
+    @mock.patch("src.python.aws._aws_profile", return_value="default")
+    @mock.patch("src.python.aws.shell_command")
+    def test_configure_sso_uses_device_code_by_default(self, mock_shell, *_):
+        env = dict(os.environ)
+        env.pop("AWS_SSO_USE_DEVICE_CODE", None)
+        with mock.patch.dict(os.environ, env, clear=True):
+            _aws_sso_login()
+        cmd = mock_shell.call_args.args[0]
+        self.assertIn("aws configure sso", cmd)
+        self.assertIn("--use-device-code", cmd)
 
 
 class _FakeResult:

--- a/src/tests/aws.test.py
+++ b/src/tests/aws.test.py
@@ -1,12 +1,17 @@
 #!/usr/bin/env python3
 
+import io
+import json
 import os
 import unittest
+from contextlib import redirect_stdout
 from unittest import mock
 
 from src.python.aws import (
     _aws_env_credentials_set,
+    _aws_export_credentials,
     _aws_sso_profile_configured,
+    aws_cli_set,
     aws_load_credentials,
 )
 
@@ -109,6 +114,51 @@ class Test_AwsSsoProfileConfigured(unittest.TestCase):
         mock_cli_get.side_effect = lambda key, **kwargs: values[key]
 
         self.assertFalse(_aws_sso_profile_configured())
+
+
+class _FakeResult:
+    def __init__(self, returncode=0, stdout=b"", stderr=b""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+class Test_SecretsNotEchoed(unittest.TestCase):
+    @mock.patch("src.python.aws.shell_command")
+    def test_aws_cli_set_does_not_echo_value(self, mock_shell):
+        mock_shell.return_value = _FakeResult()
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            aws_cli_set("aws_secret_access_key", "topsecretvalue", verbose=True)
+
+        output = buf.getvalue()
+        self.assertNotIn("topsecretvalue", output)
+        # The generic runner must be invoked with verbose disabled so it does
+        # not echo the command (which contains the secret value).
+        self.assertFalse(mock_shell.call_args.kwargs.get("verbose", False))
+
+    @mock.patch("src.python.aws.aws_cli_set")
+    @mock.patch("src.python.aws.shell_command")
+    def test_export_credentials_does_not_echo_secrets(self, mock_shell, mock_set):
+        payload = {
+            "AccessKeyId": "ASIAEXAMPLE",
+            "SecretAccessKey": "secretkeyvalue",
+            "SessionToken": "sessiontokenvalue",
+        }
+        mock_shell.return_value = _FakeResult(stdout=json.dumps(payload).encode())
+
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            result = _aws_export_credentials(verbose=True)
+
+        output = buf.getvalue()
+        self.assertTrue(result)
+        self.assertNotIn("secretkeyvalue", output)
+        self.assertNotIn("sessiontokenvalue", output)
+        # export-credentials returns secrets on stdout, so it must run with
+        # verbose disabled to avoid the generic runner echoing them.
+        self.assertFalse(mock_shell.call_args.kwargs.get("verbose", False))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Replace the non-standard `aws login --remote` with the official AWS CLI SSO flow: `aws sso login` when a profile is already configured, falling back to `aws configure sso` for first-time setup.
- Default to the SSO **device-code flow** (`--use-device-code`) so sign-in works on headless / remote-SSH hosts where the browser callback is unreachable; opt out with `AWS_SSO_USE_DEVICE_CODE=0`.
- Add profile awareness — `_aws_cli_get` accepts a `--profile`, and `_aws_sso_profile_configured` detects modern `sso-session` and legacy inline SSO profiles. Profile names are `shlex`-quoted.
- Harden verbose logging so AWS secret values (access keys, session tokens) are never echoed when reading/setting AWS CLI config or exporting SSO credentials.
- Document the SSO flow and the device-code option in the README.

## Test plan
- [x] Full unit suite passes in the container (`src/tests/run_all.sh`): 47 tests across `aws`, `deploy_command`, `deployer`, `utils`.
- [x] `Test_AwsSsoProfileConfigured`, `Test_AwsUseDeviceCode`, `Test_AwsSsoLoginCommand`, and `Test_SecretsNotEchoed` cover profile detection, the device-code toggle, command construction, and secret redaction.
- [x] Manual: validated end-to-end over remote SSH — device-code login succeeds, STS validation passes, credentials export for Terraform with no secrets printed.
