### PR TITLE
Add AI operator-agent guide and skills for using Isaac Automator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,55 @@
+# Isaac Automator - Agent Instructions <!-- omit in toc -->
+
+- [Operator quickstart (the short version)](#operator-quickstart-the-short-version)
+- [Rules for agents (read before acting)](#rules-for-agents-read-before-acting)
+- [Map](#map)
+
+This repository is **Isaac Automator**: a command-line tool that deploys Isaac Sim, Isaac Lab, and Isaac Lab
+Arena to public clouds (AWS, GCP, Azure, Alibaba Cloud) as ready-to-use GPU **Isaac Workstations** (a remote
+desktop cloud VM with the Isaac apps installed, plus start/stop/destroy lifecycle and data transfer).
+
+If you are an AI agent working with this repository, first decide your role:
+
+- **Operating** Isaac Automator - you want to *use* the tool: deploy a workstation, connect to it, run a
+  demo, stop/start it, and tear it down. **Read [`automator.agent.md`](automator.agent.md) and follow the
+  procedures in [`skills/`](skills/).** That is the entry point for operator agents. Start there.
+- **Developing** Isaac Automator - you want to *change* the tool itself (its Python CLI, Terraform, or
+  Ansible). See [`README.md`](README.md) and [`CONTRIBUTING.md`](CONTRIBUTING.md). The operator docs are not
+  for editing source.
+
+## Operator quickstart (the short version)
+
+The full procedures are in `skills/`; this is the orientation.
+
+1. **Prerequisite:** Docker running, cloud credentials available, then `./build` once.
+2. **Everything runs in a container.** The top-level scripts (`./deploy-aws`, `./start`, `./novnc`, ...) wrap
+   commands that run inside the `isaac_automator` Docker image. Run them from the repo root.
+3. **Deploy:** `./deploy-<cloud>` with options; e.g. install Isaac Lab and a demo in one shot. See
+   `skills/deploy-workstation.skill.md`.
+4. **Connect:** `./novnc <name>` (2D desktop), NoMachine (live 3D viewport), or `./ssh <name>` (shell). See
+   `skills/connect-workstation.skill.md`.
+5. **Control cost / clean up:** `./stop <name>`, `./start <name>`, and `./destroy <name> --yes`. See
+   `skills/manage-lifecycle.skill.md`.
+
+## Rules for agents (read before acting)
+
+- **It provisions real, paid cloud infrastructure.** Treat every deploy/start as live-fire. Use the cheapest
+  viable GPU instance unless told otherwise.
+- **Always clean up what you create.** Stop when idle; **destroy** (`./destroy <name> --yes`) when done -
+  stopped instances still bill for storage, only destroy stops all cost.
+- **Run non-interactively.** The deploy commands prompt for any required option you omit; an unanswered prompt
+  hangs an agent forever. Pass every required option on the command line, and use `--existing replace` (not
+  `ask`). For a headless invocation that does not need a TTY, call the container directly:
+  `docker run --rm --network host -v "$(pwd)":/app isaac_automator "<command>"`.
+- **Never print, paste, or commit credentials.** Pass them via environment variables (e.g.
+  `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) and reference them by name only.
+- **Viewport over remote desktop:** noVNC shows the 2D desktop but generally not the live Isaac Sim 3D
+  viewport (Omniverse Kit renders via a Vulkan surface VNC does not capture). Use **NoMachine** for live 3D,
+  or capture rendered output headlessly with the app's own recorder. Details in
+  `skills/connect-workstation.skill.md` and `skills/troubleshoot.skill.md`.
+
+## Map
+
+- [`automator.agent.md`](automator.agent.md) - operator agent entry point (mental model, golden rules, skills index).
+- [`skills/`](skills/) - step-by-step operator procedures (deploy, run-demos, connect, lifecycle, transfer-data, troubleshoot).
+- [`README.md`](README.md) - full human documentation for using and understanding the tool.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+@AGENTS.md
+
+<!--
+This file points Claude Code at the shared agent instructions in AGENTS.md
+(the agents.md standard, also read by other agents). Keep guidance in AGENTS.md
+so every agent shares one source of truth; this file just imports it.
+
+If you are operating Isaac Automator (deploy / connect / run / stop / destroy a
+workstation), the entry point is automator.agent.md and the procedures in skills/.
+-->

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Isaac Automator allows quick deployment of Isaac Sim, Isaac Lab, and Isaac Lab A
 The result is a fully configured deployed Isaac Workstation — a remote desktop cloud VM that you can use to develop and test robotic applications within minutes and on a budget. Isaac Automator supports a variety of GPU instances and stop/start functionality to save on cloud costs and provides tools to aid your workflow (uploading and downloading data, autorun, deployment management, etc.).
 
 - [TLDR ;)](#tldr-)
+- [Using with AI Agents](#using-with-ai-agents)
 - [Installation](#installation)
   - [Installing Docker](#installing-docker)
   - [Building the Container](#building-the-container)
@@ -53,6 +54,19 @@ The result is a fully configured deployed Isaac Workstation — a remote desktop
 ```
 
 Replace `deploy-aws` with `deploy-gcp`, `deploy-azure`, or `deploy-alicloud` for other clouds. See sections below for details.
+
+## Using with AI Agents
+
+Isaac Automator ships first-class instructions for AI agents that want to operate it.
+
+- **To operate Isaac Automator** (deploy a workstation, connect, run demos, stop/start, destroy), start with
+  [`automator.agent.md`](automator.agent.md) and follow the step-by-step procedures in [`skills/`](skills/).
+- Agent-aware tools auto-discover [`AGENTS.md`](AGENTS.md) (and [`CLAUDE.md`](CLAUDE.md) for Claude Code),
+  which route to that operator guide and summarize the cost/safety and non-interactive rules an agent must
+  follow.
+
+These describe *using* Isaac Automator as an operator. To develop the tool itself, see the sections below and
+[`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## Installation
 

--- a/automator.agent.md
+++ b/automator.agent.md
@@ -1,0 +1,119 @@
+# Isaac Automator - Operator Agent <!-- omit in toc -->
+
+- [What Isaac Automator does](#what-isaac-automator-does)
+- [Mental model](#mental-model)
+- [Prerequisites](#prerequisites)
+- [Golden rules (read before deploying)](#golden-rules-read-before-deploying)
+- [The operator loop](#the-operator-loop)
+- [Running commands non-interactively](#running-commands-non-interactively)
+- [Skills](#skills)
+- [Connecting: which method shows what](#connecting-which-method-shows-what)
+
+This file is the entry point for an **AI agent that operates Isaac Automator as a user** - to deploy a cloud
+GPU workstation, connect to it, run demos, and tear it down. It is written for the *operator* role, not the
+*developer* role: you drive the existing command-line tool, you do not edit its source (Python, Terraform,
+Ansible). If you need to change how Isaac Automator itself works, that is a development task and out of scope
+here.
+
+If you are an agent and you just want to "get a working Isaac Sim / Isaac Lab machine in the cloud and use
+it", you are in the right place. Read this file once, then open the matching skill in `skills/` for the task
+at hand and follow it.
+
+## What Isaac Automator does
+
+Isaac Automator deploys **Isaac Sim**, **Isaac Lab**, and **Isaac Lab Arena** onto a GPU virtual machine in a
+public cloud (AWS, GCP, Azure, or Alibaba Cloud) and configures it as a ready-to-use remote **Isaac
+Workstation**: a GPU VM with a remote desktop, the requested Isaac apps installed, lifecycle controls
+(start / stop / destroy), and data upload/download. It can also install ready-made **demos** that show up as
+double-click shortcuts on the desktop.
+
+## Mental model
+
+- **Everything runs inside one Docker image** (`isaac_automator`). The top-level scripts (`./deploy-aws`,
+  `./start`, ...) are thin wrappers that run the real command inside that container. You build the image once
+  with `./build`.
+- **A deployment has a name** (`--deployment-name` / `--dn`, e.g. `my-rig`). Every command after deploy takes
+  that name. Its files (ssh key, terraform state, connection info) live under `state/<name>/`.
+- **It provisions real, paid cloud infrastructure.** A deployment is a live GPU instance that bills by the
+  hour until you stop it, plus disk that bills until you destroy it.
+- **Two long-lived layers per deployment:** the cloud resources (created by deploy, removed by destroy) and
+  the running instance (started/stopped to control compute cost; the public IP is preserved across
+  stop/start).
+
+## Prerequisites
+
+> **Where you run these commands:** from the Isaac Automator repo root - the directory that holds this file
+> along with `./build`, `./deploy-aws`, `./start`, etc. All paths below are relative to that root.
+
+1. **Docker** installed and running on the machine you operate from.
+2. **Cloud credentials** for the target cloud (see `skills/deploy-workstation.skill.md` for how each cloud is
+   authenticated). For AWS the simplest path is `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` in the
+   environment, forwarded into the container.
+3. **Build the image once:** `./build` (rebuild only if the tool itself changed).
+
+## Golden rules (read before deploying)
+
+- **It costs money.** Treat every deploy/start as live-fire. Use the cheapest viable GPU instance unless told
+  otherwise, and prefer `--from-image` when speed/cost matters.
+- **Always clean up what you create.** Stop the instance when idle (`./stop`), and **destroy** the deployment
+  when done (`./destroy <name> --yes`). Stopped instances still bill for storage; only destroy stops all cost.
+- **Use unique deployment names**, especially in a shared cloud account, so your resources are easy to find
+  and never collide with someone else's.
+- **Always pass options non-interactively.** The deploy commands prompt for missing required values; in an
+  agent context an unanswered prompt hangs forever. Supply every required option on the command line.
+- **Never print, paste, or commit credentials.** Reference them by name, pass them via environment variables.
+
+## The operator loop
+
+```
+./build                      # once
+  -> deploy-workstation       # ./deploy-<cloud> ... (creates infra + installs apps/demos)
+     -> connect-workstation   # ./novnc / ./ssh / NoMachine
+        -> run-demos          # launch a demo on the desktop
+        -> transfer-data      # ./upload / ./download
+     -> manage-lifecycle      # ./stop (idle) / ./start (resume) / ./repair
+  -> ./destroy <name> --yes   # when finished (stops all billing)
+```
+
+## Running commands non-interactively
+
+The `./run` wrapper uses `docker run -it`, which needs a TTY and fails in a non-interactive shell with
+`cannot attach stdin to a TTY-enabled container`. When you are an agent driving this headlessly, invoke the
+container directly instead of relying on a TTY:
+
+```sh
+docker run --rm --network host -v "$(pwd)":/app \
+  -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
+  isaac_automator "<command and args>"
+```
+
+The top-level scripts (`./deploy-aws`, `./stop`, ...) detect when they are outside the container and start it
+for you, which is fine for interactive use; for reliable automation prefer the explicit `docker run` form
+above (it is what the skills use).
+
+## Skills
+
+Open the matching file in `skills/` and follow it. Each is a self-contained operator procedure.
+
+| Skill | Use it to |
+|---|---|
+| `skills/deploy-workstation.skill.md` | Deploy a new Isaac Workstation to AWS / GCP / Azure / Alibaba, with the apps (and demos) you want. |
+| `skills/run-demos.skill.md` | List and launch the out-of-the-box demos (e.g. quadruped locomotion RL). |
+| `skills/connect-workstation.skill.md` | Connect via noVNC (browser), NoMachine (best for 3D), or SSH. |
+| `skills/manage-lifecycle.skill.md` | Check status, stop/start to control cost, repair, and destroy. |
+| `skills/transfer-data.skill.md` | Upload inputs, download results, and set an autorun script. |
+| `skills/troubleshoot.skill.md` | Diagnose the common failure modes (blank viewport, driver mismatch, hung prompts, ...). |
+
+## Connecting: which method shows what
+
+This matters because it is the most common point of confusion:
+
+- **noVNC** (browser, `./novnc <name>`) shows the **2D desktop** reliably - good for launching apps, files, a
+  terminal. It generally does **not** show the live Isaac Sim 3D viewport, because Omniverse Kit renders
+  through a Vulkan surface that the VNC server does not capture. The window is there and running, but the
+  viewport area can look empty.
+- **NoMachine** (native client) is **GPU/Vulkan-aware** and is the reliable way to watch the live Isaac Sim /
+  Isaac Lab 3D viewport. Use it when you actually need to see rendered robots.
+- **SSH** (`./ssh <name>`) is for the shell: logs, launching commands, recording video headlessly.
+- To capture rendered output programmatically (no display), use the app's own recorder (e.g. Isaac Lab's
+  `--video`) rather than screenshotting noVNC.

--- a/skills/connect-workstation.skill.md
+++ b/skills/connect-workstation.skill.md
@@ -1,0 +1,62 @@
+---
+name: connect-workstation
+triggers: ["connect to the workstation", "open novnc", "ssh into the rig", "use nomachine", "how do I see the desktop"]
+summary: Connect to a deployed Isaac Workstation via noVNC (browser), NoMachine (3D), or SSH (shell).
+---
+
+# connect-workstation <!-- omit in toc -->
+
+- [Pick the right method](#pick-the-right-method)
+- [noVNC (browser desktop)](#novnc-browser-desktop)
+- [NoMachine (live 3D viewport)](#nomachine-live-3d-viewport)
+- [SSH (shell)](#ssh-shell)
+
+You need a deployed, running workstation (see `deploy-workstation.skill.md`; resume a stopped one with
+`./start <name>`). All connection info is also saved in `state/<name>/info.txt`.
+
+## Pick the right method
+
+| Want to... | Use |
+|---|---|
+| Click around the desktop, launch apps, open a terminal | noVNC |
+| Watch the live Isaac Sim / Isaac Lab 3D viewport (rendered robots) | NoMachine |
+| Run commands, read logs, launch a demo headlessly | SSH |
+
+The 3D viewport is the key distinction: Omniverse Kit renders via a Vulkan surface that noVNC does **not**
+capture, so the live 3D shows under NoMachine, not noVNC.
+
+## noVNC (browser desktop)
+
+```sh
+./novnc <name>
+```
+
+This prints a URL of the form
+`http://<ip>:6080/vnc.html?host=<ip>&port=6080&password=<vnc_password>&resize=scale`. Open it in a browser
+(add `&autoconnect=true` to connect immediately). The VNC password is the one set at deploy
+(`--vnc-password`, or the random value saved in `state/<name>/meta.json`). noVNC requires port 6080 to be
+reachable from your IP - deploy with `--ingress-cidrs myip` so it is.
+
+## NoMachine (live 3D viewport)
+
+1. Install the NoMachine client from https://downloads.nomachine.com/ and launch it.
+2. Add a connection to **Host** = the workstation public IP.
+3. Use key-based auth with the private key at `state/<name>/key.pem`.
+4. Connect and log in as the SSH user (default `ubuntu`).
+
+NoMachine is GPU/Vulkan-aware, so this is what to use when you actually need to see rendered output.
+
+## SSH (shell)
+
+```sh
+./ssh <name>
+```
+
+Or directly with the saved key:
+
+```sh
+ssh -i state/<name>/key.pem -o StrictHostKeyChecking=no ubuntu@<ip>
+```
+
+Use SSH to read logs, launch a demo's `~/.local/share/isaac-automator-demos/<demo>.sh` script, or record
+viewport video headlessly. Set `DISPLAY=:0` when launching GUI apps so they render on the workstation desktop.

--- a/skills/deploy-workstation.skill.md
+++ b/skills/deploy-workstation.skill.md
@@ -1,0 +1,116 @@
+---
+name: deploy-workstation
+triggers: ["deploy isaac", "deploy a workstation", "spin up isaac sim", "create an isaac lab machine", "get me a cloud GPU with isaac"]
+summary: Deploy a new Isaac Workstation (Isaac Sim / Isaac Lab / Arena, optional demos) to a public cloud, non-interactively.
+---
+
+# deploy-workstation <!-- omit in toc -->
+
+- [1. Pick the basics](#1-pick-the-basics)
+- [2. Set up credentials](#2-set-up-credentials)
+- [3. Build the image (once)](#3-build-the-image-once)
+- [4. Deploy](#4-deploy)
+- [5. Per-cloud specifics](#5-per-cloud-specifics)
+- [6. After deploy](#6-after-deploy)
+- [Faster, cheaper deploys (--from-image)](#faster-cheaper-deploys---from-image)
+
+Deploy a fully configured Isaac Workstation. This provisions **real, paid** cloud resources - confirm the
+target, cloud, and that cleanup will happen before you start. A full source deploy takes roughly 45-60 min;
+`--from-image` is roughly 10-15 min.
+
+## 1. Pick the basics
+
+- **Cloud:** `aws` | `gcp` | `azure` | `alicloud`.
+- **Deployment name** (`--deployment-name`): unique, lowercase letters / digits / `-`, <= 32 chars. e.g.
+  `demo-rig-1`.
+- **Region** and **instance type**: each cloud has a default; pick the cheapest viable GPU instance unless
+  told otherwise. Cheap viable picks: AWS `g5.2xlarge`, Azure `Standard_NV6ads_A10_v5`, GCP `g2-standard-8`,
+  Alibaba `ecs.gn7i-c16g1.4xlarge`.
+- **What to install:** any of Isaac Sim (`--isaacsim`), Isaac Lab (`--isaaclab`), Isaac Lab Arena
+  (`--isaaclab-arena`). Each takes a git ref (e.g. a release tag) or `no` to skip.
+- **Demos** (`--demos`): a comma-separated list, or `no`. A demo auto-enables the apps it needs (see
+  `run-demos.skill.md`). e.g. `--demos quadruped-locomotion` will turn on Isaac Sim + Isaac Lab for you.
+
+## 2. Set up credentials
+
+- **AWS (simplest):** export `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` and forward them into the
+  container with `-e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY`. If those are not set, the tool falls back to
+  the AWS IAM Identity Center (SSO) device-code login flow, which needs a human to open a URL and enter a
+  code - avoid in headless automation.
+- **GCP / Azure / Alibaba:** authenticate with that cloud's normal CLI/credentials before deploying; the
+  container reads the standard credential locations (mounted via the working directory). Obtain credentials
+  from the user if you do not have them.
+
+Never echo or commit these values.
+
+## 3. Build the image (once)
+
+```sh
+./build
+```
+
+Only needed once per machine (or after the tool itself changes).
+
+## 4. Deploy
+
+Pass **every** required option so nothing prompts. Headless-safe form (AWS shown):
+
+```sh
+docker run --rm --network host -v "$(pwd)":/app \
+  -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
+  isaac_automator \
+  "unset AWS_PROFILE; ./deploy-aws \
+     --deployment-name demo-rig-1 \
+     --region us-east-1 \
+     --instance-type g5.2xlarge \
+     --not-from-image \
+     --ingress-cidrs myip \
+     --isaacsim v6.0.0 \
+     --isaaclab release/3.0.0-beta2 \
+     --isaaclab-arena no \
+     --demos quadruped-locomotion \
+     --existing replace \
+     --no-upload \
+     --debug"
+```
+
+Key common options (all clouds):
+
+- `--deployment-name` / `--dn` - the name used by every later command.
+- `--ingress-cidrs` - who may reach the VM. `myip` = your current public IP only (recommended). Also accepts
+  explicit CIDRs, or `0.0.0.0/0` for anywhere (not recommended).
+- `--isaacsim` / `--isaaclab` / `--isaaclab-arena` - git ref to install, or `no`.
+- `--demos` - demos to install, or `no` (auto-enables required apps).
+- `--from-image` / `--not-from-image` - deploy from a pre-built image (fast) or from bare OS (full).
+- `--existing` - what to do if the name already exists: `replace` (delete and redeploy), `repair`, `modify`,
+  `run_ansible`, or `ask` (do not use `ask` in automation - it prompts).
+- `--upload` / `--no-upload` - upload your local `uploads/` to the VM during deploy.
+- `--vnc-password`, `--system-user-password` - set explicitly if you want known values (otherwise random).
+- `--debug` - verbose progress; useful when streaming a long deploy.
+
+Long deploys: run it detached and stream milestones (`terraform` actions, Ansible `PLAY [` / `TASK [`
+headers, `fatal:` / `Error`, and the final `PLAY RECAP`) rather than waiting blind. Success looks like a
+`PLAY RECAP` with `failed=0`.
+
+## 5. Per-cloud specifics
+
+- **AWS** (`./deploy-aws`): `--region`, `--instance-type`. Default instance is an L40S `g6e.2xlarge`.
+- **GCP** (`./deploy-gcp`): adds `--zone`, `--project`, and `--isaac-workstation-gpu-count` (1/2/4/8).
+- **Azure** (`./deploy-azure`): adds `--resource-group` and `--login` / `--no-login`.
+- **Alibaba** (`./deploy-alicloud`): `--region` (default `us-east-1`).
+
+## 6. After deploy
+
+The command prints (and saves to `state/<name>/info.txt`) the public IP and how to connect via SSH, noVNC,
+and NoMachine. Next:
+
+- Connect: `connect-workstation.skill.md`.
+- Run a demo: `run-demos.skill.md`.
+- Control cost / tear down: `manage-lifecycle.skill.md`.
+
+## Faster, cheaper deploys (--from-image)
+
+A full deploy builds Isaac Sim from source (slow). To deploy many times quickly, first bake a pre-built image
+once with `./image-aws` / `./image-gcp` / `./image-azure`, then deploy with `--from-image` (roughly 10-15 min
+and far cheaper per deploy). Use a full `--not-from-image` deploy when you specifically need to validate a
+from-scratch install or no pre-built image exists.

--- a/skills/manage-lifecycle.skill.md
+++ b/skills/manage-lifecycle.skill.md
@@ -1,0 +1,75 @@
+---
+name: manage-lifecycle
+triggers: ["stop the workstation", "start the rig", "destroy the deployment", "repair isaac", "check deployment status", "how much is it costing"]
+summary: Control a deployment's cost and health - status, stop/start, repair, and destroy.
+---
+
+# manage-lifecycle <!-- omit in toc -->
+
+- [Cost model (why this matters)](#cost-model-why-this-matters)
+- [Status](#status)
+- [Stop (pause billing for compute)](#stop-pause-billing-for-compute)
+- [Start (resume)](#start-resume)
+- [Repair](#repair)
+- [Destroy (stop all billing)](#destroy-stop-all-billing)
+
+Every command takes the deployment name you chose at deploy.
+
+## Cost model (why this matters)
+
+- A **running** instance bills for compute (the expensive part) plus storage.
+- A **stopped** instance bills only for storage (cheap, but not zero).
+- **Destroying** removes the resources and stops all billing.
+
+So: `./stop` when idle, `./start` to resume, and `./destroy` when you are truly done. The public IP is
+preserved across stop/start, so connection URLs keep working after a resume.
+
+## Status
+
+Check whether the instance exists and its state (running / stopped / ...). Quick direct check on AWS:
+
+```sh
+docker run --rm -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY isaac_automator \
+  "unset AWS_PROFILE; AWS_DEFAULT_REGION=<region> aws ec2 describe-instances \
+     --filters Name=tag:Deployment,Values=<name> \
+     --query 'Reservations[].Instances[].[InstanceId,State.Name]' --output text"
+```
+
+You can also read `state/<name>/info.txt` for the saved connection details.
+
+## Stop (pause billing for compute)
+
+```sh
+./stop <name>
+```
+
+Stops the instance but keeps it (and its disk + IP). Use whenever you are done for now but will come back.
+
+## Start (resume)
+
+```sh
+./start <name>
+```
+
+Boots the stopped instance again; same IP. After boot the autorun launches the default app on the desktop.
+If a `./start --quick` runs Ansible before sshd is ready you may see `unreachable=1` - just re-run `./start`.
+
+## Repair
+
+```sh
+./repair <name>
+```
+
+Re-applies configuration without changing your chosen parameters. Use it when a deployment came up unhealthy
+(e.g. a service did not start, or after an image driver/library mismatch + reboot).
+
+## Destroy (stop all billing)
+
+```sh
+./destroy <name> --yes
+```
+
+Deletes the deployment's cloud resources. This is the only thing that stops storage cost. **Always destroy
+what you created when you are finished.** Afterward, verify nothing tagged with your deployment name remains
+(instances, VPC, static IPs); if `./destroy` failed partway (e.g. a dependency error on the VPC), clean up the
+leftover resources by hand and re-run.

--- a/skills/run-demos.skill.md
+++ b/skills/run-demos.skill.md
@@ -1,0 +1,81 @@
+---
+name: run-demos
+triggers: ["run a demo", "list demos", "launch quadruped demo", "show me isaac lab training", "what demos are available"]
+summary: Install and launch the out-of-the-box Isaac demos that ship as desktop shortcuts on the workstation.
+---
+
+# run-demos <!-- omit in toc -->
+
+- [What demos are](#what-demos-are)
+- [Available demos](#available-demos)
+- [1. Enable a demo at deploy time](#1-enable-a-demo-at-deploy-time)
+- [2. Launch it](#2-launch-it)
+- [3. Watch it](#3-watch-it)
+- [Tuning a demo](#tuning-a-demo)
+
+## What demos are
+
+Demos are curated, ready-to-run examples installed on the workstation as **double-click desktop shortcuts**,
+chosen at deploy time with `--demos`. Selecting a demo **auto-enables the apps it depends on** (e.g. Isaac Sim
+and Isaac Lab), so one flag is enough to get a working setup. Each demo also installs a launcher script under
+`~/.local/share/isaac-automator-demos/<demo>.sh` that you can run directly over SSH.
+
+## Available demos
+
+- **`quadruped-locomotion`** - trains an ANYmal-D quadruped to walk with RSL-RL in Isaac Lab, rendered in the
+  Isaac Sim viewport. Depends on Isaac Sim + Isaac Lab (auto-enabled).
+
+To see the current list for a given build, check the `--demos` help on a deploy command, or look under
+`src/ansible/roles/demos/tasks/` in the source.
+
+## 1. Enable a demo at deploy time
+
+Add `--demos <name>[,<name>...]` to the deploy command (see `deploy-workstation.skill.md`). Example:
+
+```sh
+./deploy-aws --deployment-name demo-rig-1 --region us-east-1 --instance-type g5.2xlarge \
+  --not-from-image --ingress-cidrs myip --isaaclab-arena no \
+  --demos quadruped-locomotion --existing replace --no-upload --debug
+```
+
+You do not need to pass `--isaacsim` / `--isaaclab` - the demo turns them on with their default versions if
+you left them off. (You can still pass explicit versions to pin them.)
+
+## 2. Launch it
+
+Two ways:
+
+- **Interactive:** connect via the desktop (NoMachine or noVNC) and double-click the demo shortcut on the
+  desktop (e.g. "Quadruped Locomotion RL Demo"). It opens a terminal and starts the run.
+- **Over SSH (headless-friendly):** run the launcher script on the workstation's display:
+
+  ```sh
+  ./ssh <name>
+  # then on the VM:
+  DISPLAY=:0 ~/.local/share/isaac-automator-demos/quadruped-locomotion.sh
+  ```
+
+The quadruped demo prints live RSL-RL training output (per-iteration reward and metrics) as it runs.
+
+## 3. Watch it
+
+The 3D viewport renders through Omniverse Kit's Vulkan surface, which **noVNC does not capture** - over noVNC
+you will see the desktop but usually a blank viewport. To watch the live robots, connect with **NoMachine**
+(see `connect-workstation.skill.md`).
+
+To get a rendered file without a display, run the underlying Isaac Lab script with video recording instead of
+relying on a screen capture, e.g. add `--headless --enable_cameras --video --video_length 600` to a
+`train.py` / `play.py` invocation; the videos are written under the run's `logs/.../videos/` directory.
+
+## Tuning a demo
+
+The quadruped launcher honors environment variables, so you can adjust it without editing anything:
+
+```sh
+HEADLESS=1 NUM_ENVS=4096 MAX_ITERATIONS=1500 \
+  ~/.local/share/isaac-automator-demos/quadruped-locomotion.sh
+```
+
+- `HEADLESS=1` - no GUI window (fastest training; nothing to watch).
+- `NUM_ENVS` - parallel environments (more = faster learning, heavier GPU; lower for a lighter live view).
+- `MAX_ITERATIONS` - how long to train.

--- a/skills/transfer-data.skill.md
+++ b/skills/transfer-data.skill.md
@@ -1,0 +1,43 @@
+---
+name: transfer-data
+triggers: ["upload data to the workstation", "download results", "get files off the rig", "set an autorun script", "auto-launch on boot"]
+summary: Move data to/from a workstation and configure what runs automatically on boot.
+---
+
+# transfer-data <!-- omit in toc -->
+
+- [Upload inputs](#upload-inputs)
+- [Download results](#download-results)
+- [Autorun on boot](#autorun-on-boot)
+
+Standard folders on the workstation: `~/uploads` (inputs you send up), `~/results` (outputs to bring back),
+`~/workspace` (general working dir). Locally they map to the `uploads/` and `results/` folders next to the
+scripts.
+
+## Upload inputs
+
+Put files in the local `uploads/` folder, then:
+
+```sh
+./upload <name>
+```
+
+This copies your local `uploads/` to `~/uploads` on the workstation. You can also upload during deploy by
+passing `--upload` (default) instead of `--no-upload`.
+
+## Download results
+
+```sh
+./download <name>
+```
+
+This pulls `~/results` from the workstation into your local `results/` folder. Pulling artifacts back is an
+explicit action - it does not happen automatically.
+
+## Autorun on boot
+
+To have the workstation automatically launch something when it boots (instead of the default Isaac Sim),
+place a script at `uploads/autorun.sh` locally. It is uploaded to `~/uploads/autorun.sh` and, when present,
+the desktop runs it on boot (and after each start). Use this to auto-launch a specific app or, for example, a
+demo launcher (`~/.local/share/isaac-automator-demos/<demo>.sh`). Without an autorun script, the workstation
+starts Isaac Sim by default.

--- a/skills/troubleshoot.skill.md
+++ b/skills/troubleshoot.skill.md
@@ -1,0 +1,84 @@
+---
+name: troubleshoot
+triggers: ["isaac sim viewport is black", "deploy hangs", "command is stuck", "cannot connect", "driver mismatch", "demo wont show"]
+summary: Diagnose and fix the common Isaac Automator failure modes from the operator side.
+---
+
+# troubleshoot <!-- omit in toc -->
+
+- [Viewport is blank over noVNC](#viewport-is-blank-over-novnc)
+- [A command hangs forever](#a-command-hangs-forever)
+- [cannot attach stdin to a TTY-enabled container](#cannot-attach-stdin-to-a-tty-enabled-container)
+- [Deploy or start finished but the machine is unhealthy](#deploy-or-start-finished-but-the-machine-is-unhealthy)
+- [start ran Ansible before SSH was ready (unreachable=1)](#start-ran-ansible-before-ssh-was-ready-unreachable1)
+- [Cannot reach noVNC / SSH](#cannot-reach-novnc--ssh)
+- [AWS credentials rejected or SSO prompt appears](#aws-credentials-rejected-or-sso-prompt-appears)
+- [Forgot what is still running / leftover cost](#forgot-what-is-still-running--leftover-cost)
+
+## Viewport is blank over noVNC
+
+Expected, not a bug. Omniverse Kit renders the 3D viewport through a Vulkan surface that the VNC server does
+not capture, so noVNC shows the desktop but an empty viewport. To see rendered output:
+
+- Connect with **NoMachine** (GPU/Vulkan-aware) - see `connect-workstation.skill.md`; or
+- Record the viewport headlessly with the app's own recorder (Isaac Lab `--video --enable_cameras`), then
+  download the file.
+
+The app is still running; only the live display path is the issue.
+
+## A command hangs forever
+
+Almost always an unanswered interactive prompt. The deploy commands prompt for any required option you did
+not supply, and `--existing ask` prompts too. Fix: pass **every** required option non-interactively and use
+`--existing replace` (or `repair` / `modify` / `run_ansible`), never `ask`, in automation.
+
+## cannot attach stdin to a TTY-enabled container
+
+`./run` (and the auto-container path) uses `docker run -it`, which needs a TTY. In a headless/agent shell,
+invoke the container directly instead:
+
+```sh
+docker run --rm --network host -v "$(pwd)":/app \
+  -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
+  isaac_automator "<command>"
+```
+
+## Deploy or start finished but the machine is unhealthy
+
+Run `./repair <name>` to re-apply configuration without changing your parameters. A common cause on
+`--from-image` deploys is a stale NVIDIA driver/library version mismatch; reboot the instance, then
+`./repair`.
+
+## start ran Ansible before SSH was ready (unreachable=1)
+
+A fast start can kick off configuration before sshd is up, giving `unreachable=1`. Just run `./start <name>`
+again once the instance has finished booting.
+
+## Cannot reach noVNC / SSH
+
+The security group only allows the CIDRs you set at deploy. If you deployed with `--ingress-cidrs myip` and
+your public IP changed (or you are connecting from a different network), the ports are no longer open to you.
+Re-deploy with `--existing modify` and the correct `--ingress-cidrs`, or add your current IP. noVNC needs
+port 6080 and SSH needs the SSH port (default 22) reachable from your address.
+
+## AWS credentials rejected or SSO prompt appears
+
+If `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` are unset or invalid, the tool falls back to the AWS SSO
+device-code login, which blocks waiting for a human. For headless runs, set valid env-var credentials and
+forward them with `-e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY`, and `unset AWS_PROFILE` in the command so
+the env vars take precedence.
+
+## Forgot what is still running / leftover cost
+
+List your resources by deployment tag and destroy when done:
+
+```sh
+# what is still tagged to this deployment (AWS)
+aws ec2 describe-instances --filters Name=tag:Deployment,Values=<name> \
+  --query 'Reservations[].Instances[].[InstanceId,State.Name]' --output text
+
+./destroy <name> --yes   # removes resources, stops all billing
+```
+
+If `./destroy` fails partway (e.g. a VPC dependency error), remove the leftover resources by hand and re-run
+until nothing tagged with your deployment name remains.


### PR DESCRIPTION
## Summary

Adds first-class **AI-agent operator instructions** so an AI agent can drive Isaac Automator as a *user*
(deploy a workstation, connect, run demos, stop/start, destroy) without needing to understand the source.

- **`automator.agent.md`** - operator entry point: what Isaac Automator is, the Docker / named-deployment
  mental model, prerequisites, golden rules (billable, always destroy, non-interactive, no secrets), the
  operator loop, the headless `docker run` invocation, a skills index, and a "which connect method shows
  what" note (noVNC vs NoMachine vs SSH).
- **`skills/`** - six step-by-step operator procedures:
  - `deploy-workstation` - deploy to AWS / GCP / Azure / Alibaba, non-interactively, with per-cloud options.
  - `run-demos` - install and launch the out-of-the-box demos as desktop shortcuts.
  - `connect-workstation` - noVNC (2D desktop), NoMachine (live 3D viewport), SSH (shell).
  - `manage-lifecycle` - status, stop/start for cost control, repair, destroy.
  - `transfer-data` - upload inputs, download results, set an autorun script.
  - `troubleshoot` - common failure modes (blank viewport, hung prompts, TTY error, driver mismatch, ingress).
- **`AGENTS.md`** (the agents.md standard, auto-discovered by agent-aware tools) and **`CLAUDE.md`**
  (`@AGENTS.md` for Claude Code) - route agents to the operator guide and surface the cost/safety and
  non-interactive rules up front.
- **`README.md`** - new "Using with AI Agents" section + TOC entry pointing at the above.

## Notes

- These are *operator* docs (using the tool); developing the tool itself is unchanged and still covered by
  the README / CONTRIBUTING.
- Naming: used `AGENTS.md` (the widely-adopted agents.md convention, read by Cursor and others) with
  `CLAUDE.md` importing it, so all agents share one source of truth.
- The `run-demos` skill documents the `--demos` out-of-the-box demos capability proposed in a separate PR; it
  is written defensively (points at `--demos` help for the current build) and is harmless if that capability
  is not present.

Opened as a **draft** for review.